### PR TITLE
Instrument Configuration Updates and other Edits

### DIFF
--- a/docs/source/design/index.rst
+++ b/docs/source/design/index.rst
@@ -1,9 +1,8 @@
 .. _design__guidelines:
 
-===============
-Garnet Design
-===============
-IN PROGRESS
+============================
+Garnet Design - IN PROGRESS
+============================
 
 Information, diagrams and flowcharts are included about the various components of GARNET.
 Please make sure to

--- a/docs/source/design/index.rst
+++ b/docs/source/design/index.rst
@@ -1,14 +1,13 @@
 .. _design__guidelines:
 
-============================
-Garnet Design - IN PROGRESS
-============================
+===============
+Garnet Design
+===============
 
 Information, diagrams and flowcharts are included about the various components of GARNET.
 Please make sure to
 review and adhere to these guidelines when contributing to the project.
 
-The design content is in progress.
 
 Contents
 --------

--- a/docs/source/design/index.rst
+++ b/docs/source/design/index.rst
@@ -3,11 +3,13 @@
 ===============
 Garnet Design
 ===============
+IN PROGRESS
 
 Information, diagrams and flowcharts are included about the various components of GARNET.
 Please make sure to
 review and adhere to these guidelines when contributing to the project.
 
+The design content is in progress.
 
 Contents
 --------

--- a/docs/source/design/instrument.rst
+++ b/docs/source/design/instrument.rst
@@ -5,6 +5,8 @@ Instrument Model
 
 The Instrument model is described in `Data Dictionary Instrument Configuration <https://ornlrse.clm.ibmcloud.com/rm/web#action=com.ibm.rdm.web.pages.showArtifactPage&artifactURI=https%3A%2F%2Fornlrse.clm.ibmcloud.com%2Frm%2Fresources%2FTX_gl6-gMwZEe6kustJDRk6kQ&componentURI=https%3A%2F%2Fornlrse.clm.ibmcloud.com%2Frm%2Frm-projects%2F_DADVIOHJEeyU5_2AJWnXOQ%2Fcomponents%2F_DEP4oOHJEeyU5_2AJWnXOQ&vvc.configuration=https%3A%2F%2Fornlrse.clm.ibmcloud.com%2Frm%2Fcm%2Fstream%2F_DEcs8OHJEeyU5_2AJWnXOQ>`_.
 
+The BaseInstrumentModel defines each physical instrument and the InstrumentInfoModel defines the configuration settings used for one or more experiments.
+
 .. mermaid::
 
  classDiagram
@@ -53,38 +55,38 @@ The InstrumentInfo is created from the InstrumentConfiguration Settings. Based o
     * WAND2
     * DEMAND
 
-The InstrumentInfoModel model captures the changes in the configuration parameters for a specific instrument, e.g. DEMAND can have two InstrumentObjects
-with different parameters. The state_info includes the description of the change/upgrade for that instrument.
+The InstrumentInfoModel model captures the changes in the configuration parameters for a specific instrument, e.g. DEMAND can have two InstrumentInfoObjects
+with different parameters. The state_info (optionally) includes the description of the change/upgrade for that instrument.
 
 .. mermaid::
 
     classDiagram
-        InstrumentInfoModel <|-- SNAPInstrumentObject
-        InstrumentInfoModel <|-- CORELLIInstrumentObject
-        InstrumentInfoModel <|-- TOPAZInstrumentObject
-        InstrumentInfoModel <|-- MANDIInstrumentObject
-        InstrumentInfoModel <|-- WAND2InstrumentObject
-        InstrumentInfoModel <|-- DEMANDInstrumentObject
+        InstrumentInfoModel <|-- SNAPInfo
+        InstrumentInfoModel <|-- CORELLIInfo
+        InstrumentInfoModel <|-- TOPAZInfo
+        InstrumentInfoModel <|-- MANDIInfo
+        InstrumentInfoModel <|-- WAND2Info
+        InstrumentInfoModel <|-- DEMANDInfo
 
         class InstrumentInfoModel{
             <>
         }
 
-        class SNAPInstrumentObject{
+        class SNAPInfo{
             <>
         }
-        class CORELLIInstrumentObject{
+        class CORELLIInfo{
             <>
         }
-        class TOPAZInstrumentObject{
+        class TOPAZInfo{
             <>
         }
-        class MANDIInstrumentObject{
+        class MANDIInfo{
             <>
         }
-        class WAND2InstrumentObject{
+        class WAND2Info{
             <>
         }
-        class DEMANDInstrumentObject{
+        class DEMANDInfo{
             <>
         }

--- a/docs/source/design/instrument.rst
+++ b/docs/source/design/instrument.rst
@@ -8,20 +8,29 @@ The Instrument model is described in `Data Dictionary Instrument Configuration <
 .. mermaid::
 
  classDiagram
-    InstrumentModel "1" *--"3" InstrumentProjectionFieldModel: grouping_field,run_number_field, scale_field
-    InstrumentModel "1" *--"N<=3" InstrumentGoniometerAngleModel
+    BaseInstrumentModel <|-- InstrumentInfoModel
+    InstrumentInfoModel "1" *--"1" InstrumentProjectionRunSchema
+    InstrumentInfoModel "1" *--"N<=3" InstrumentGoniometerAngleModel
 
-    class InstrumentModel{
+    class BaseInstrumentModel{
+        <<Abstract>>
         +String facility
         +String filesystem_name
         +String reference_name
-        +List~Number~[1|2] wavelength
-        +String raw_file_format
-        +List~InstrumentGoniometerAngleModel~ goniometer_settings
-        +List~InstrumentProjectionFieldModel~ run_schema
         +create()
 
     }
+
+    class InstrumentInfoModel{
+        +String state_info
+        +List~Number~[1|2] wavelength
+        +String raw_file_format
+        +List~InstrumentGoniometerAngleModel~ goniometer_settings
+        +InstrumentProjectionRunSchema run_schema
+        +create()
+
+    }
+
     class InstrumentGoniometerAngleModel{
         +String name
         +String reference_name
@@ -30,9 +39,52 @@ The Instrument model is described in `Data Dictionary Instrument Configuration <
         +Bool used_in_goniometer_setting
         +get_angle_field_name()
     }
-    class InstrumentProjectionFieldModel{
-        +String field_name
-        +String oncat_meta_field
+    class InstrumentProjectionRunSchema{
+        +grouping_field
+        +run_number_field
+        +scale_field
     }
 
-The Instrument is created from the InstrumentConfiguration Settings.
+The InstrumentInfo is created from the InstrumentConfiguration Settings. Based on the information, we can create the following instruments:
+    * SNAP
+    * CORELLI
+    * TOPAZ
+    * MANDI
+    * WAND2
+    * DEMAND
+
+The InstrumentInfoModel model captures the changes in the configuration parameters for a specific instrument, e.g. DEMAND can have two InstrumentObjects
+with different parameters. The state_info includes the description of the change/upgrade for that instrument.
+
+.. mermaid::
+
+    classDiagram
+        InstrumentInfoModel <|-- SNAPInstrumentObject
+        InstrumentInfoModel <|-- CORELLIInstrumentObject
+        InstrumentInfoModel <|-- TOPAZInstrumentObject
+        InstrumentInfoModel <|-- MANDIInstrumentObject
+        InstrumentInfoModel <|-- WAND2InstrumentObject
+        InstrumentInfoModel <|-- DEMANDInstrumentObject
+
+        class InstrumentInfoModel{
+            <>
+        }
+
+        class SNAPInstrumentObject{
+            <>
+        }
+        class CORELLIInstrumentObject{
+            <>
+        }
+        class TOPAZInstrumentObject{
+            <>
+        }
+        class MANDIInstrumentObject{
+            <>
+        }
+        class WAND2InstrumentObject{
+            <>
+        }
+        class DEMANDInstrumentObject{
+            <>
+        }

--- a/docs/source/design/instrument.rst
+++ b/docs/source/design/instrument.rst
@@ -3,6 +3,8 @@
 Instrument Model
 =======================
 
+IN PROGRESS
+
 The Instrument model is described in `Data Dictionary Instrument Configuration <https://ornlrse.clm.ibmcloud.com/rm/web#action=com.ibm.rdm.web.pages.showArtifactPage&artifactURI=https%3A%2F%2Fornlrse.clm.ibmcloud.com%2Frm%2Fresources%2FTX_gl6-gMwZEe6kustJDRk6kQ&componentURI=https%3A%2F%2Fornlrse.clm.ibmcloud.com%2Frm%2Frm-projects%2F_DADVIOHJEeyU5_2AJWnXOQ%2Fcomponents%2F_DEP4oOHJEeyU5_2AJWnXOQ&vvc.configuration=https%3A%2F%2Fornlrse.clm.ibmcloud.com%2Frm%2Fcm%2Fstream%2F_DEcs8OHJEeyU5_2AJWnXOQ>`_.
 
 The BaseInstrumentModel defines each physical instrument and the InstrumentInfoModel defines the configuration settings used for one or more experiments.

--- a/docs/source/design/oncat.rst
+++ b/docs/source/design/oncat.rst
@@ -3,6 +3,8 @@
 PyOnCat Model
 ===================
 
+IN PROGRESS
+
 The PyOnCat is described in `Data Dictionary OnCat <https://ornlrse.clm.ibmcloud.com/rm/web#action=com.ibm.rdm.web.pages.showArtifactPage&artifactURI=https%3A%2F%2Fornlrse.clm.ibmcloud.com%2Frm%2Fresources%2FTX_X6q9wNStEe6uLrx4w2K0Ew&vvc.configuration=https%3A%2F%2Fornlrse.clm.ibmcloud.com%2Frm%2Fcm%2Fstream%2F_DEcs8OHJEeyU5_2AJWnXOQ&componentURI=https%3A%2F%2Fornlrse.clm.ibmcloud.com%2Frm%2Frm-projects%2F_DADVIOHJEeyU5_2AJWnXOQ%2Fcomponents%2F_DEP4oOHJEeyU5_2AJWnXOQ>`_ .
 
 The detailed Instrument model is found here :ref:`Instrument <instrument>`.

--- a/docs/source/design/oncat.rst
+++ b/docs/source/design/oncat.rst
@@ -5,7 +5,7 @@ PyOnCat Model
 
 The PyOnCat is described in `Data Dictionary OnCat <https://ornlrse.clm.ibmcloud.com/rm/web#action=com.ibm.rdm.web.pages.showArtifactPage&artifactURI=https%3A%2F%2Fornlrse.clm.ibmcloud.com%2Frm%2Fresources%2FTX_X6q9wNStEe6uLrx4w2K0Ew&vvc.configuration=https%3A%2F%2Fornlrse.clm.ibmcloud.com%2Frm%2Fcm%2Fstream%2F_DEcs8OHJEeyU5_2AJWnXOQ&componentURI=https%3A%2F%2Fornlrse.clm.ibmcloud.com%2Frm%2Frm-projects%2F_DADVIOHJEeyU5_2AJWnXOQ%2Fcomponents%2F_DEP4oOHJEeyU5_2AJWnXOQ>`_ .
 
-The detailed Instrument model is found here :ref:`Intrument <instrument>`.
+The detailed Instrument model is found here :ref:`Instrument <instrument>`.
 Related APIS:
 
 - experiment_list: oncat.Experiment.list(facility=<facility>, instrument=<instrument>)

--- a/docs/source/design/oncat.rst
+++ b/docs/source/design/oncat.rst
@@ -18,12 +18,12 @@ Related APIS:
  classDiagram
     PyOnCatModel "1" o--"N" ExperimentModel
     ExperimentModel "1" o--"N" RunModel
-    PyOnCatModel "1" -->"1" InstrumentModel
+    PyOnCatModel "1" -->"1" InstrumentInfoModel
     RunModel "1" *--"N<=3" GoniometerAngleKeyValueModel
     RunModel "1" *--"3" ProjectionFieldKeyValueModel
 
     class PyOnCatModel{
-        +InstrumentModel instrument
+        +InstrumentInfoModel instrument
         -PyOnCat:ONCat oncat_agent
         +String data_source_filepath
         +Number selected_experiment_index
@@ -34,7 +34,7 @@ Related APIS:
         +select_experiment()
         +add_datasource_filepath()
     }
-    class InstrumentModel{
+    class InstrumentInfoModel{
         <>
     }
 

--- a/docs/source/design/oncat_general.rst
+++ b/docs/source/design/oncat_general.rst
@@ -3,6 +3,8 @@
 PyOnCat General Model
 =======================
 
+IN PROGRESS
+
 This is a generalization of :ref:`PyOnCatSchema <pyoncat>`, in case it can be used for other applications other than garnet that want to achieve a similar functionality.
 
 The detailed Instrument model is found here :ref:`Intrument <instrument>`.

--- a/docs/source/design/oncat_mvp.rst
+++ b/docs/source/design/oncat_mvp.rst
@@ -3,6 +3,8 @@
 PyOnCat Model-View-Presenter
 ==============================
 
+IN PROGRESS
+
 The data, graphical interface and functionality components related to OnCat are described here. The related code
 is organized in Model-View-Presenter pattern.
 

--- a/docs/source/design/reduction_plan.rst
+++ b/docs/source/design/reduction_plan.rst
@@ -3,6 +3,8 @@
 Reduction Plan Model
 =======================
 
+IN PROGRESS
+
 The Reduction Plan is described in `Data Dictionary Reduction Plan <https://ornlrse.clm.ibmcloud.com/rm/web#action=com.ibm.rdm.web.pages.showArtifactPage&artifactURI=https%3A%2F%2Fornlrse.clm.ibmcloud.com%2Frm%2Fresources%2FTX_FsGEMM9tEe6kustJDRk6kQ&vvc.configuration=https%3A%2F%2Fornlrse.clm.ibmcloud.com%2Frm%2Fcm%2Fstream%2F_DEcs8OHJEeyU5_2AJWnXOQ&componentURI=https%3A%2F%2Fornlrse.clm.ibmcloud.com%2Frm%2Frm-projects%2F_DADVIOHJEeyU5_2AJWnXOQ%2Fcomponents%2F_DEP4oOHJEeyU5_2AJWnXOQ>`_.
 Every parameter below is collected during the reduction plan creation, besides ub_matrix that is calculated during the UB Matrix/Peaks Finding step.
 

--- a/docs/source/design/reduction_plan.rst
+++ b/docs/source/design/reduction_plan.rst
@@ -11,20 +11,23 @@ The detailed Instrument model is found here :ref:`Intrument <instrument>`.
 .. mermaid::
 
  classDiagram
-    ReductionPlanModel "N" -->"1" InstrumentModel
+    ReductionPlanModel "1" *--"1" InstrumentInfoModel
     ReductionPlanModel "1" *--"1" CalibrationModel
     ReductionPlanModel "1" *--"1" NormalizationModel
 
     class ReductionPlanModel{
         -String reduction_plan_id
         +String reduction_plan_name
-        +InstrumentModel instrument
+        +InstrumentInfoModel instrument
         +String experiment
+        +Number ipts_experiment_number
         +String run_range
         +List~Number~ wavelength
         +String mask_filepath
         +String background_filepath
         +String grouping
+        +Number elastic
+        +Bool offset
         +String reduction_plan_filepath
         +String data_source_filepath
         +CalibrationModel calibration
@@ -41,7 +44,7 @@ The detailed Instrument model is found here :ref:`Intrument <instrument>`.
         +reduction_plan_filepath()
     }
 
-    class InstrumentModel{
+    class InstrumentInfoModel{
         <>
     }
 
@@ -76,6 +79,14 @@ The above validation functions check the following before the Reduction Plan cre
     * the run range files exist in the instrument/experiment filepath.
     * the reduction plan filepath is unique. In case of a new reduction plan with an exisiting filepath warning message is sent to the user to ask whether they want to override the existing one.
 
+There are parameters available to specific instruments for the reducton plan creation:
+    * detector_filepath available for SNAP, CORELLI, TOPAZ and MANDI. Not required.
+    * tube_filepath available only for CORELLI. Not required.
+    * elastic available only for CORELLI. Not required.
+    * offset available only for CORELLI. Required (True or False).
+    * ipts_experiment_number available only for DEMAND. Required.
+    * wavelength (band) 2nd field available only for SNAP, CORELLI, TOPAZ, MANDI. Required.
+
 The reduction_plan_id is created and assigned during the Reduction Plan creation. It is a unique identifier that is passed along with the reduction plan name and any other necessary parameters between View and Model.
 
 In case any of the above do not pass, an error message is sent and displayed to the user.
@@ -89,8 +100,11 @@ Below is the expected schema for the Reduction Plan saved in a file:
             +String Instrument
             +List~Number~ Wavelength
             +Number Experiment
+            +Number IPTSExperimentNumber
             +String RunRange
             +String Grouping
+            +Number Elastic
+            +Bool Offset
             +String UBFile
             +String VanadiumFile
             +String BackgroundFile
@@ -109,4 +123,4 @@ Reduction pla file validation rules:
 
     * If the data values are missing or invalid, a reduction plan object is not created. The parameters are sent and displayed to the user to fix them. A corresponding error message is displayed to promt the user to edit the parameters and then save the reduction plan.
 
-    * If data keys (fields) are missing, the file is considered corrupted. No parameters are loaded andan error message is sent and displayed to the user.
+    * If data keys (fields) are missing, the file is considered corrupted. No parameters are loaded and an error message is sent and displayed to the user.

--- a/docs/source/design/reduction_plan.rst
+++ b/docs/source/design/reduction_plan.rst
@@ -26,8 +26,8 @@ The detailed Instrument model is found here :ref:`Intrument <instrument>`.
         +String mask_filepath
         +String background_filepath
         +String grouping
-        +Number elastic
-        +Bool offset
+        +Number offset
+        +Bool elastic
         +String reduction_plan_filepath
         +String data_source_filepath
         +CalibrationModel calibration

--- a/docs/source/design/reduction_plan.rst
+++ b/docs/source/design/reduction_plan.rst
@@ -82,8 +82,8 @@ The above validation functions check the following before the Reduction Plan cre
 There are parameters available to specific instruments for the reducton plan creation:
     * detector_filepath available for SNAP, CORELLI, TOPAZ and MANDI. Not required.
     * tube_filepath available only for CORELLI. Not required.
-    * elastic available only for CORELLI. Not required.
-    * offset available only for CORELLI. Required (True or False).
+    * elastic available only for CORELLI. Required. (True or False)
+    * offset available only for CORELLI. Not Required.
     * ipts_experiment_number available only for DEMAND. Required.
     * wavelength (band) 2nd field available only for SNAP, CORELLI, TOPAZ, MANDI. Required.
 

--- a/docs/source/design/reduction_plan_mvp.rst
+++ b/docs/source/design/reduction_plan_mvp.rst
@@ -77,7 +77,7 @@ The View is described below:
         ReductionPlanTab "1" -->"1" ReductionPlanWidget
         ReductionPlanTasksWidget "1" -->"1" ReductionPlanListWidget
         ReductionPlanWidget "1" -->"1" RunsWidget
-        ReductionPlanWidget "1" -->"1" GoniometerWavelengthWidget
+        ReductionPlanWidget "1" -->"1" InstrumentDataWidget
         ReductionPlanWidget "1" -->"1" DataSourceWidget
         ReductionPlanWidget "1" -->"1" NormalizationWidget
         ReductionPlanWidget "1" -->"1" CalibrationWidget
@@ -132,7 +132,7 @@ The View is described below:
             +QComboBox:instrument
             +DataSourceWidget:data_source
             +RunsWidget:runs
-            +GoniometerWavelengthWidget:goniometer
+            +InstrumentDataWidget:instrument
             +CalibrationWidget:calibration
             +BtnFileWidget: ub
             +QLabel:grouping_display
@@ -181,7 +181,11 @@ The View is described below:
         }
 
 
-        class GoniometerWavelengthWidget{
+        class InstrumentDataWidget{
+            +QLabel:elastic_display
+            +QLineEdit:elastic
+            +QLabel:offset_display
+            +QCheckBox:offset
             +QLabel:goniometer_table_display
             +QTableWidget:goniometer_table
             +QLabel:wavelength_display
@@ -235,10 +239,21 @@ The wireframe for the above class diagram is here: `Garnet Wireframe <https://ba
 All validation related to invalid and required fields for the reduction plan submit (Add/Edit) button
 are added here:
 
-    #. required parameters
+    #. required parameters; all fields marked with * in the wireframe are required for the reduction plan creation: name, instrument (InstrumentInfoModel), experiment, run_ranges, wavelength, grouping, reduction_plan_file and ipts_experiment_number only for DEMAND
     #. run range format
     #. wavelength format
     #. file path format of every file in: datasource, calibration, vanadium and ub and reduction plan file sections
+
+Instrument-specific fields:
+
+    There are certain fields that are hidden/displayed for specific instruments. Their visibility is handled at the time of the Instrument selection.
+    These are the following:
+        #. detector_filepath displayed for SNAP, CORELLI, TOPAZ and MANDI.
+        #. tube_filepath displayed only for CORELLI.
+        #. elastic displayed only for CORELLI.
+        #. offset displayed only for CORELLI.
+        #. ipts_experiment_number displayed only for DEMAND.
+        #. wavelength (band) 2nd field displayed only for SNAP, CORELLI, TOPAZ, MANDI.
 
 In case the selected reduction plan is in an invalid state, the next steps buttons/tabs are deactivated.
 A reduction plan is created only and only if it is in a valid state.

--- a/docs/source/design/reduction_plan_mvp.rst
+++ b/docs/source/design/reduction_plan_mvp.rst
@@ -18,10 +18,9 @@ The Model is described in detail:
     classDiagram
         ReductionPlanTabModel "1" -->"1" ReductionPlanListModel
         ReductionPlanTabModel "1" -->"1" PyOnCatModel
-        ReductionPlanTabModel "1" o--"N<=6" InstrumentModel
         ReductionPlanListModel "1" o--"N" ReductionPlanModel
-        ReductionPlanModel "N" -->"1" InstrumentModel
-        PyOnCatModel "1" -->"1" InstrumentModel
+        ReductionPlanModel "N" -->"1" InstrumentInfoModel
+        PyOnCatModel "1" -->"1" InstrumentInfoModel
 
         class ReductionPlanListModel{
             -String:selected_plan
@@ -36,15 +35,11 @@ The Model is described in detail:
 
         class ReductionPlanTabModel{
             +ReductionPlanListModel reduction_plan_list
-            +List~InstrumentModel~ instrument_list
             +PyOnCatModel pyoncat_data
             +add_instrument()
             +get_instrument()
         }
 
-        class InstrumentModel{
-            <>
-        }
 
         class ReductionPlanModel{
             <>
@@ -57,7 +52,7 @@ The Model is described in detail:
 
 The ReductionPlanListModel model contains the user's reduction plans and the one selected for
 data reduction in further steps (ReductionPlanModel). Additionally, it maintains the list
-of the instruments (InstrumentModel) generated during the reduction plan creation process per user's selections.
+of the instruments (InstrumentInfoModel) generated during the reduction plan creation process per user's selections.
 Finally the runs of experiments with their fields based on the selected instrument and OnCat-related
 information are stored (PyOnCatModel), too.
 The selected plan (ReductionPlanModel) is passed for the next step.

--- a/docs/source/design/reduction_plan_mvp.rst
+++ b/docs/source/design/reduction_plan_mvp.rst
@@ -248,6 +248,7 @@ Instrument-specific fields:
 
     There are certain fields that are hidden/displayed for specific instruments. Their visibility is handled at the time of the Instrument selection.
     These are the following:
+
         #. detector_filepath displayed for SNAP, CORELLI, TOPAZ and MANDI.
         #. tube_filepath displayed only for CORELLI.
         #. elastic displayed only for CORELLI.

--- a/docs/source/design/reduction_plan_mvp.rst
+++ b/docs/source/design/reduction_plan_mvp.rst
@@ -3,6 +3,8 @@
 Reduction Plan Model-View-Presenter
 ========================================
 
+IN PROGRESS
+
 The data, graphical interface and functionality components related to the first step
 -- Reduction Plan Screen -- are described here. The related code
 is organized in the Model-View-Presenter pattern.

--- a/docs/source/design/reduction_plan_mvp.rst
+++ b/docs/source/design/reduction_plan_mvp.rst
@@ -178,9 +178,9 @@ The View is described below:
 
         class InstrumentDataWidget{
             +QLabel:elastic_display
-            +QLineEdit:elastic
+            +QCheckBox:elastic
             +QLabel:offset_display
-            +QCheckBox:offset
+            +QLineEdit:offset
             +QLabel:goniometer_table_display
             +QTableWidget:goniometer_table
             +QLabel:wavelength_display


### PR DESCRIPTION
## Description of Changes:
It includes instrument configuration updates (before NDIP) and some additional reduction plan settings.
The design pages are marked as in progress

## Related Items
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if aplicable -->

## To Test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test.
If you have created a manual test, provide the code here as well.
You can provide a manual test in a code block using:
```python
# some python code
```
-->

```bash
cd /path/to/my/local/garnet/repo/
git fetch origin pull/<PULL_REQUEST_NUMBER>/head:pr<PULL_REQUEST_NUMBER>
git switch pr<PULL_REQUEST_NUMBER>
conda activate <garnet_environment>
python -m pytest <item_to_test>
```
<!--
In the above code snippet, substitute `<PULL_REQUEST_NUMBER>` for the actual merge request number. Also substitute
`<garnet_environment>` with the name of the conda environment you use for development. It is critical that
you have installed the repo in this conda environment in editable mode with `pip install -e .` or `conda develop .`
Substitute `<item_to_test>` with the path to the file or directory of your test. If you have multiple tests in multiple locations, please list them.
-->

## Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

---

## Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
